### PR TITLE
Corrected link to Groovy documentatin

### DIFF
--- a/groovy.html.markdown
+++ b/groovy.html.markdown
@@ -405,7 +405,7 @@ assert sum(2,5) == 7
 
 ## Further resources
 
-[Groovy documentation](http://groovy.codehaus.org/Documentation)
+[Groovy documentation](http://www.groovy-lang.org/documentation.html)
 
 [Groovy web console](http://groovyconsole.appspot.com/)
 


### PR DESCRIPTION
Link was to Codehaus, now defunct. 
